### PR TITLE
Concluding the building moves

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,10 @@ install:
   - pip install -r requirements.txt
 
 script:
-    - make html
-    - mv _build/html/* .
-     #- sphinx-apidoc -fo docstrings pyxem #do locally    
+    - make html #this takes the .rst files in docs and turns them into html files
+    - mv _build/html/* . # see PR #16              
+    #- sphinx-apidoc -fo docstrings pyxem #do locally  
+    - mv docstring/_build/html/* ./docstring # see PR #16   
 deploy:
   provider: pages
   skip_cleanup: true


### PR DESCRIPTION
Our travis now contains some `mv` sections.

(reading from top, lines labelled with comments to `PR #16`)
1) Moves the newly built html up a couple of directory to keep the files paths shorter.
2) Moves the locally built html up, with the same idea in mind, docstrings are always at a URL that includes `/docstrings/`