### PR TITLE
Make kikuchipy URL point to kikuchipy.org

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -61,7 +61,7 @@ diffsims - for creating diffraction simulations. `Github <http://pyxem.github.io
 
 orix - for quaternion, rotation, and orientation handling in Python. `Github <http://pyxem.github.io/pyxem/orix>`__
 
-kikuchipy - for processing and analysing EBSD data. `Github <http://pyxem.github.io/pyxem/kikuchipy>`__
+kikuchipy - for processing and analysing EBSD data. `Webpage <https://kikuchipy.org>`__
 
 other important packages
 ------------------------


### PR DESCRIPTION
Signed-off-by: Håkon Wiik Ånes <hwaanes@gmail.com>

Thanks a lot for including kikuchipy on this page, and in the news!!

I would just like to make a slight change to the kikuchipy URL, so that it to point to https://kikuchipy.org instead of to http://pyxem.github.io/pyxem/kikuchipy, which returns a 404.

Is my change enough for the website to update, or do I need to do something else?